### PR TITLE
Revert "use cstrings ~ let user handle it"

### DIFF
--- a/wrappers.odin
+++ b/wrappers.odin
@@ -184,8 +184,8 @@ get_monitor_name :: #force_inline proc(monitor: Monitor_Handle) -> string {
     return cast(string)bind.GetMonitorName(monitor); // TODO: is this safe?
 }
 
-get_clipboard_string :: #force_inline proc(window: Window_Handle) -> cstring {
-    return bind.GetClipboardString(window);
+get_clipboard_string :: #force_inline proc(window: Window_Handle) -> string {
+    return cast(string)bind.GetClipboardString(window); // TODO: is this safe?
 }
 
 get_video_modes :: #force_inline proc(monitor: Monitor_Handle) -> []Vid_Mode {
@@ -378,8 +378,8 @@ get_gamepad_state :: #force_inline proc(jid: Joystick) -> (Gamepad_State, bool) 
     return state, ret;
 }
 
-set_clipboard_string :: #force_inline proc(window: Window_Handle, str: cstring) {
-    bind.SetClipboardString(window, str);
+set_clipboard_string :: #force_inline proc(window: Window_Handle, str: string) {
+    if len(str) > 0 do bind.SetClipboardString(window, strings.unsafe_string_to_cstring(str)); // TODO: is this safe? (string -> cstring)
 }
 
 get_time :: #force_inline proc() -> f64 {


### PR DESCRIPTION
Reverts vassvik/odin-glfw#12

Causing too many issues for now in my own code bases, so to save me and others more trouble than not I'll revert this.

I should have paid more attention from the start and probably rejected this:
- It does not touch the other wrappers that does similar things
- There are bindings that take cstrings directly already om the bindings package.
