### PR TITLE
Fix Monitor and Joystick callbacks

### DIFF
--- a/bindings/bindings.odin
+++ b/bindings/bindings.odin
@@ -127,6 +127,9 @@ foreign glfw {
 
     GetRequiredInstanceExtensions ::  proc(count: ^u32) -> ^cstring ---;
 
+    SetMonitorCallback  :: proc(cbfun: Monitor_Proc) -> Monitor_Proc ---;
+    SetJoystickCallback :: proc(cbfun: Joystick_Proc) -> Joystick_Proc ---;
+
     SetWindowIconifyCallback      :: proc(window: Window_Handle, cbfun: Window_Iconify_Proc) -> Window_Iconify_Proc ---;
     SetWindowRefreshCallback      :: proc(window: Window_Handle, cbfun: Window_Refresh_Proc) -> Window_Refresh_Proc ---;
     SetWindowFocusCallback        :: proc(window: Window_Handle, cbfun: Window_Focus_Proc) -> Window_Focus_Proc ---;
@@ -135,7 +138,6 @@ foreign glfw {
     SetWindowPosCallback          :: proc(window: Window_Handle, cbfun: Window_Pos_Proc) -> Window_Pos_Proc ---;
     SetFramebufferSizeCallback    :: proc(window: Window_Handle, cbfun: Framebuffer_Size_Proc) -> Framebuffer_Size_Proc ---;
     SetDropCallback               :: proc(window: Window_Handle, cbfun: Drop_Proc) -> Drop_Proc ---;
-    SetMonitorCallback            :: proc(window: Window_Handle, cbfun: Monitor_Proc) -> Monitor_Proc ---;
     SetWindowMaximizeCallback     :: proc(window: Window_Handle, cbfun: Window_Maximize_Proc) -> Window_Maximize_Proc ---;
     SetWindowContentScaleCallback :: proc(window: Window_Handle, cbfun: Window_Content_Scale_Proc) -> Window_Content_Scale_Proc ---;
 
@@ -146,7 +148,6 @@ foreign glfw {
     SetCharCallback        :: proc(window: Window_Handle, cbfun: Char_Proc) -> Char_Proc ---;
     SetCharModsCallback    :: proc(window: Window_Handle, cbfun: Char_Mods_Proc) -> Char_Mods_Proc ---;
     SetCursorEnterCallback :: proc(window: Window_Handle, cbfun: Cursor_Enter_Proc) -> Cursor_Enter_Proc ---;
-    SetJoystickCallback    :: proc(window: Window_Handle, cbfun: Joystick_Proc) -> Joystick_Proc ---;
 
     SetErrorCallback :: proc(cbfun: Error_Proc) -> Error_Proc ---;
     

--- a/bindings/types.odin
+++ b/bindings/types.odin
@@ -29,6 +29,9 @@ Gamepad_State :: struct {
 };
 
 /*** Procedure type declarations ***/
+Monitor_Proc  :: #type proc "c" (monitor: Monitor_Handle, event: i32);
+Joystick_Proc :: #type proc "c" (joy, event: i32);
+
 Window_Iconify_Proc       :: #type proc "c" (window: Window_Handle, iconified: i32);
 Window_Refresh_Proc       :: #type proc "c" (window: Window_Handle);
 Window_Focus_Proc         :: #type proc "c" (window: Window_Handle, focused: i32);
@@ -39,7 +42,6 @@ Window_Maximize_Proc      :: #type proc "c" (window: Window_Handle, iconified: i
 Window_Content_Scale_Proc :: #type proc "c" (window: Window_Handle, xscale, yscale: f32);
 Framebuffer_Size_Proc     :: #type proc "c" (window: Window_Handle, width, height: i32);
 Drop_Proc                 :: #type proc "c" (window: Window_Handle, count: i32, paths: ^cstring);
-Monitor_Proc              :: #type proc "c" (window: Window_Handle);
 
 Key_Proc          :: #type proc "c" (window: Window_Handle, key, scancode, action, mods: i32);
 Mouse_Button_Proc :: #type proc "c" (window: Window_Handle, button, action, mods: i32);
@@ -48,6 +50,5 @@ Scroll_Proc       :: #type proc "c" (window: Window_Handle, xoffset, yoffset: f6
 Char_Proc         :: #type proc "c" (window: Window_Handle, codepoint: rune);
 Char_Mods_Proc    :: #type proc "c" (window: Window_Handle, codepoint: rune, mods: i32);
 Cursor_Enter_Proc :: #type proc "c" (window: Window_Handle, entered: i32);
-Joystick_Proc     :: #type proc "c" (joy, event: i32);
 
 Error_Proc            :: #type proc "c" (error: i32, description: cstring);

--- a/wrappers.odin
+++ b/wrappers.odin
@@ -414,6 +414,14 @@ extension_supported :: #force_inline proc(extension: string) -> bool {
     return cast(bool)bind.ExtensionSupported(strings.unsafe_string_to_cstring(extension)); // TODO: is this safe?
 }
 
+set_monitor_callback :: #force_inline proc(cbfun: Monitor_Proc) -> Monitor_Proc {
+    return bind.SetMonitorCallback(cbfun);
+}
+
+set_joystick_callback :: #force_inline proc(cbfun: Joystick_Proc) -> Joystick_Proc {
+    return bind.SetJoystickCallback(cbfun);
+}
+
 set_window_iconify_callback :: #force_inline proc(window: Window_Handle, cbfun: Window_Iconify_Proc) -> Window_Iconify_Proc {
     return bind.SetWindowIconifyCallback(window, cbfun);
 }
@@ -444,10 +452,6 @@ set_framebuffer_size_callback :: #force_inline proc(window: Window_Handle, cbfun
 
 set_drop_callback :: #force_inline proc(window: Window_Handle, cbfun: Drop_Proc) -> Drop_Proc {
     return bind.SetDropCallback(window, cbfun);
-}
-
-set_monitor_callback :: #force_inline proc(window: Window_Handle, cbfun: Monitor_Proc) -> Monitor_Proc {
-    return bind.SetMonitorCallback(window, cbfun);
 }
 
 set_window_maximize_callback :: #force_inline proc(window: Window_Handle, cbfun: Window_Maximize_Proc) -> Window_Maximize_Proc {
@@ -484,10 +488,6 @@ set_char_mods_callback :: #force_inline proc(window: Window_Handle, cbfun: Char_
 
 set_cursor_enter_callback :: #force_inline proc(window: Window_Handle, cbfun: Cursor_Enter_Proc) -> Cursor_Enter_Proc {
     return bind.SetCursorEnterCallback(window, cbfun);
-}
-
-set_joystick_callback :: #force_inline proc(window: Window_Handle, cbfun: Joystick_Proc) -> Joystick_Proc {
-    return bind.SetJoystickCallback(window, cbfun);
 }
 
 set_error_callback :: #force_inline proc(cbfun: Error_Proc) -> Error_Proc {


### PR DESCRIPTION
Both glfwSetMonitorCallback and glfwSetJoystickCallback do not take a window handle. Also the Monitor callback takes different arguments.